### PR TITLE
Swap pitch bend LSB and MSB

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -543,44 +543,6 @@ mod tests {
     }
 
     #[test]
-    fn should_parse_pitchbend_0_0_to_negative_1() {
-        let mut parser = MidiByteStreamParser::new();
-        parser.parse(0xE1);
-        parser.parse(0x00);
-        let msg = parser.parse(0x00);
-
-        match msg {
-            Some(MidiMessage::PitchBendChange(_, val_u14)) => assert_eq!(f32::from(val_u14), -1.0),
-            _ => assert!(false),
-        }
-    }
-
-    #[test]
-    fn should_parse_pitchbend_midway_to_zero() {
-        let mut parser = MidiByteStreamParser::new();
-        parser.parse(0xE1);
-        parser.parse(0x00);
-        let msg = parser.parse(0x40);
-
-        match msg {
-            Some(MidiMessage::PitchBendChange(_, val_u14)) => assert_eq!(f32::from(val_u14), 0.0),
-            _ => assert!(false),
-        }
-    }
-    #[test]
-    fn should_parse_pitchbend_fullscale_to_positive_1() {
-        let mut parser = MidiByteStreamParser::new();
-        parser.parse(0xE1);
-        parser.parse(0x7F);
-        let msg = parser.parse(0x7F);
-
-        match msg {
-            Some(MidiMessage::PitchBendChange(_, val_u14)) => assert_eq!(f32::from(val_u14), 1.0),
-            _ => assert!(false),
-        }
-    }
-
-    #[test]
     fn should_parse_quarter_frame() {
         MidiByteStreamParser::new()
             .assert_result(&[0xf1, 0x7f], &[MidiMessage::QuarterFrame(0x7f.into())]);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -47,7 +47,7 @@ enum MidiParserState {
     ChannelPressureRecvd(Channel),
 
     PitchBendRecvd(Channel),
-    PitchBendFirstByteRecvd(Channel, u8),
+    PitchBendLsbRecvd(Channel, u8),
 
     QuarterFrameRecvd,
 
@@ -221,12 +221,12 @@ impl MidiByteStreamParser {
                 }
 
                 MidiParserState::PitchBendRecvd(channel) => {
-                    self.state = MidiParserState::PitchBendFirstByteRecvd(channel, byte);
+                    self.state = MidiParserState::PitchBendLsbRecvd(channel, byte);
                     None
                 }
-                MidiParserState::PitchBendFirstByteRecvd(channel, byte1) => {
+                MidiParserState::PitchBendLsbRecvd(channel, lsb) => {
                     self.state = MidiParserState::PitchBendRecvd(channel);
-                    Some(MidiMessage::PitchBendChange(channel, (byte, byte1).into()))
+                    Some(MidiMessage::PitchBendChange(channel, (byte, lsb).into()))
                 }
                 MidiParserState::QuarterFrameRecvd => Some(MidiMessage::QuarterFrame(byte.into())),
                 MidiParserState::SongPositionRecvd => {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -226,7 +226,7 @@ impl MidiByteStreamParser {
                 }
                 MidiParserState::PitchBendFirstByteRecvd(channel, byte1) => {
                     self.state = MidiParserState::PitchBendRecvd(channel);
-                    Some(MidiMessage::PitchBendChange(channel, (byte1, byte).into()))
+                    Some(MidiMessage::PitchBendChange(channel, (byte, byte1).into()))
                 }
                 MidiParserState::QuarterFrameRecvd => Some(MidiMessage::QuarterFrame(byte.into())),
                 MidiParserState::SongPositionRecvd => {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -235,7 +235,7 @@ impl MidiByteStreamParser {
                 }
                 MidiParserState::SongPositionLsbRecvd(lsb) => {
                     self.state = MidiParserState::SongPositionRecvd;
-                    Some(MidiMessage::SongPositionPointer((lsb, byte).into()))
+                    Some(MidiMessage::SongPositionPointer((byte, lsb).into()))
                 }
                 MidiParserState::SongSelectRecvd => Some(MidiMessage::SongSelect(byte.into())),
                 _ => None,
@@ -566,7 +566,7 @@ mod tests {
     fn should_parse_song_position_pointer() {
         MidiByteStreamParser::new().assert_result(
             &[0xf2, 0x7f, 0x68],
-            &[MidiMessage::SongPositionPointer((0x7f, 0x68).into())],
+            &[MidiMessage::SongPositionPointer((0x68, 0x7f).into())],
         );
     }
 
@@ -578,8 +578,8 @@ mod tests {
                 0x23, 0x7b, // Only send data of next song position pointer
             ],
             &[
-                MidiMessage::SongPositionPointer((0x7f, 0x68).into()),
-                MidiMessage::SongPositionPointer((0x23, 0x7b).into()),
+                MidiMessage::SongPositionPointer((0x68, 0x7f).into()),
+                MidiMessage::SongPositionPointer((0x7b, 0x23).into()),
             ],
         );
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -63,8 +63,8 @@ impl MidiRenderSlice for MidiMessage {
                 chan3byte(buf, PITCH_BEND_CHANGE, c, &lsb, &msb)
             }
             MidiMessage::SongPositionPointer(v) => {
-                let (v0, v1): (u8, u8) = (*v).into();
-                chan3byte(buf, SONG_POSITION_POINTER, &0, &v0, &v1)
+                let (msb, lsb): (u8, u8) = (*v).into();
+                chan3byte(buf, SONG_POSITION_POINTER, &0, &lsb, &msb)
             }
             MidiMessage::ProgramChange(c, p) => chan2byte(buf, PROGRAM_CHANGE, c, p),
             MidiMessage::ChannelPressure(c, p) => chan2byte(buf, CHANNEL_PRESSURE, c, p),

--- a/src/render.rs
+++ b/src/render.rs
@@ -59,8 +59,8 @@ impl MidiRenderSlice for MidiMessage {
             MidiMessage::KeyPressure(c, n, v) => chan3byte(buf, KEY_PRESSURE, c, n, v),
             MidiMessage::ControlChange(c, n, v) => chan3byte(buf, CONTROL_CHANGE, c, n, v),
             MidiMessage::PitchBendChange(c, v) => {
-                let (v0, v1): (u8, u8) = (*v).into();
-                chan3byte(buf, PITCH_BEND_CHANGE, c, &v0, &v1)
+                let (msb, lsb): (u8, u8) = (*v).into();
+                chan3byte(buf, PITCH_BEND_CHANGE, c, &lsb, &msb)
             }
             MidiMessage::SongPositionPointer(v) => {
                 let (v0, v1): (u8, u8) = (*v).into();


### PR DESCRIPTION
Hello, I believe that the `PitchBendChange` struct returned by parse has the LSB and MSB swapped. While experimenting with a project I noticed that the pitch bend acted strangely, shooting towards the two extremes too rapidly and clamping at either -1 or +1.

The midi-convert crate creates a pitch bend message like this: `Some(MidiMessage::PitchBendChange(channel, (byte1, byte).into()))`. This looks like it should work, because it puts the LSB on the left and MSB on the right like you’d expect when parsing the raw MIDI byte order.

However, I believe the underlying midi-types crate puts the MSB on the left and LSB on the right when creating the `Value14` type that makes up the data part of the pitch bend message. See the `from` functions for `(u8, u8)`, `Value14`, and `u16` here: [https://docs.rs/midi-types/latest/src/midi_types/message.rs.html#283](https://docs.rs/midi-types/latest/src/midi_types/message.rs.html#283)

After a simple one line swap of the LSB and MSB the pitch bend on my test setup is working as expected.